### PR TITLE
don't loose context information regarding the original exception

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,22 +1,4 @@
-====
-    Licensed to Inspektr under one or more contributor license
-    agreements. See the NOTICE file distributed with this work
-    for additional information regarding copyright ownership.
-    Inspektr licenses this file to you under the Apache License,
-    Version 2.0 (the "License"); you may not use this file
-    except in compliance with the License. You may obtain a
-    copy of the License at:
 
-    http://www.apache.org/licenses/LICENSE-2.0
+Note: the new canonical git remote for this repository has been relocated here: https://github.com/Jasig/inspektr
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on
-    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied. See the License for the
-    specific language governing permissions and limitations
-    under the License.
-====
-
-The Inspektr project allows for non-intrusive auditing and logging of the coarse-grained execution paths e.g. Spring-managed beans method executions by using annotations and Spring-managed @Aspect-style aspects.
-
-Note: this is the new home for Inspektr project. The Google Code project home will be deleted.
+This remote will remain on GitHub, but will not be recieveing any updates.

--- a/README.txt
+++ b/README.txt
@@ -1,4 +1,4 @@
 
 Note: the new canonical git remote for this repository has been relocated here: https://github.com/Jasig/inspektr
 
-This remote will remain on GitHub, but will not be recieveing any updates.
+This remote will remain on GitHub, but will not be receiveing any updates.

--- a/inspektr-audit/src/main/java/com/github/inspektr/audit/AuditException.java
+++ b/inspektr-audit/src/main/java/com/github/inspektr/audit/AuditException.java
@@ -1,0 +1,72 @@
+package com.github.inspektr.audit;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+public class AuditException extends Exception {
+
+    /**
+     *
+     */
+    private static final long serialVersionUID = 6016858958104058800L;
+
+    private Throwable[] originalCauses;
+
+    public AuditException() {
+	super();
+    }
+
+    public AuditException(String message, Throwable cause) {
+	super(message, cause);
+    }
+
+    public AuditException(String message) {
+	super(message);
+    }
+
+    public AuditException(Throwable cause) {
+	super(cause);
+    }
+
+    public AuditException(String message, Throwable cause, Throwable... originalExceptions) {
+	super(message, cause);
+	this.originalCauses = originalExceptions;
+    }
+
+    @Override
+    public void printStackTrace(PrintStream ps) {
+	super.printStackTrace(ps);
+	ps.println("--- Additionaly, the following problems occurred: ---");
+	if (originalCauses != null) {
+	    int i = 0;
+	    for (Throwable originalCause : originalCauses) {
+		if (originalCause != null) {
+		    i++;
+		    ps.println("- Original Cause " + i + ": -");
+		    originalCause.printStackTrace(ps);
+		    ps.println("- End of Original Cause " + i + " -");
+		}
+	    }
+	}
+	ps.println("--- This is the end of the underlying problems ---");
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter pw) {
+	super.printStackTrace(pw);
+	pw.println("--- Additionaly, the following problems occurred: ---");
+	if (originalCauses != null) {
+	    int i = 0;
+	    for (Throwable originalCause : originalCauses) {
+		if (originalCause != null) {
+		    i++;
+		    pw.println("- Original Cause " + i + ": -");
+		    originalCause.printStackTrace(pw);
+		    pw.println("- End of Original Cause " + i + " -");
+		}
+	    }
+	}
+	pw.println("--- This is the end of the underlying problems ---");
+    }
+
+}

--- a/inspektr-audit/src/main/java/com/github/inspektr/audit/AuditTrailManagementAspect.java
+++ b/inspektr-audit/src/main/java/com/github/inspektr/audit/AuditTrailManagementAspect.java
@@ -19,6 +19,7 @@
 
 package com.github.inspektr.audit;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.Map;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Aspect;
+
 import com.github.inspektr.audit.annotation.Audit;
 import com.github.inspektr.audit.annotation.Audits;
 import com.github.inspektr.audit.spi.AuditActionResolver;
@@ -59,104 +61,148 @@ public final class AuditTrailManagementAspect {
     private ClientInfoResolver clientInfoResolver = new DefaultClientInfoResolver();
 
     /**
-     * Constructs an AuditTrailManagementAspect with the following parameters.  Also, registers some default AuditActionResolvers including the
-     * {@link com.github.inspektr.audit.spi.support.DefaultAuditActionResolver}, the {@link com.github.inspektr.audit.spi.support.BooleanAuditActionResolver} and the {@link com.github.inspektr.audit.spi.support.ObjectCreationAuditActionResolver}.
+     * Constructs an AuditTrailManagementAspect with the following parameters.
+     * Also, registers some default AuditActionResolvers including the
+     * {@link com.github.inspektr.audit.spi.support.DefaultAuditActionResolver},
+     * the
+     * {@link com.github.inspektr.audit.spi.support.BooleanAuditActionResolver}
+     * and the
+     * {@link com.github.inspektr.audit.spi.support.ObjectCreationAuditActionResolver}
+     * .
      *
-     * @param applicationCode            the overall code that identifies this application.
-     * @param auditablePrincipalResolver the resolver which will locate principals.
-     * @param auditTrailManagers         the list of managers to write the audit trail out to.
-     * @param auditActionResolverMap     the map of resolvers by name provided in the annotation on the method.
-     * @param auditResourceResolverMap   the map of resolvers by the name provided in the annotation on the method.
+     * @param applicationCode
+     *            the overall code that identifies this application.
+     * @param auditablePrincipalResolver
+     *            the resolver which will locate principals.
+     * @param auditTrailManagers
+     *            the list of managers to write the audit trail out to.
+     * @param auditActionResolverMap
+     *            the map of resolvers by name provided in the annotation on the
+     *            method.
+     * @param auditResourceResolverMap
+     *            the map of resolvers by the name provided in the annotation on
+     *            the method.
      */
-    public AuditTrailManagementAspect(final String applicationCode, final PrincipalResolver auditablePrincipalResolver, final List<AuditTrailManager> auditTrailManagers, final Map<String, AuditActionResolver> auditActionResolverMap, final Map<String, AuditResourceResolver> auditResourceResolverMap) {
-        this.auditPrincipalResolver = auditablePrincipalResolver;
-        this.auditTrailManagers = auditTrailManagers;
-        this.applicationCode = applicationCode;
-        this.auditActionResolvers = auditActionResolverMap;
-        this.auditResourceResolvers = auditResourceResolverMap;
+    public AuditTrailManagementAspect(final String applicationCode, final PrincipalResolver auditablePrincipalResolver,
+	    final List<AuditTrailManager> auditTrailManagers, final Map<String, AuditActionResolver> auditActionResolverMap,
+	    final Map<String, AuditResourceResolver> auditResourceResolverMap) {
+	this.auditPrincipalResolver = auditablePrincipalResolver;
+	this.auditTrailManagers = auditTrailManagers;
+	this.applicationCode = applicationCode;
+	this.auditActionResolvers = auditActionResolverMap;
+	this.auditResourceResolvers = auditResourceResolverMap;
 
     }
 
     @Around(value = "@annotation(audits)", argNames = "audits")
     public Object handleAuditTrail(final ProceedingJoinPoint joinPoint, final Audits audits) throws Throwable {
-        Object retVal = null;
-        String currentPrincipal = null;
-        final String[] actions = new String[audits.value().length];
-        final String[][] auditableResources = new String[audits.value().length][];
-        try {
-            retVal = joinPoint.proceed();
-            currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, retVal);
+	List<Throwable> originalCauses = new ArrayList<Throwable>();
+	Object retVal = null;
+	String currentPrincipal = null;
+	final String[] actions = new String[audits.value().length];
+	final String[][] auditableResources = new String[audits.value().length][];
+	try {
+	    retVal = joinPoint.proceed();
+	    currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, retVal);
 
-            if (currentPrincipal != null) {
-                for (int i = 0; i < audits.value().length; i++) {
-                    final AuditActionResolver auditActionResolver = this.auditActionResolvers.get(audits.value()[i].actionResolverName());
-                    final AuditResourceResolver auditResourceResolver = this.auditResourceResolvers.get(audits.value()[i].resourceResolverName());
-                    auditableResources[i] = auditResourceResolver.resolveFrom(joinPoint, retVal);
-                    actions[i] = auditActionResolver.resolveFrom(joinPoint, retVal, audits.value()[i]);
-                }
-            }
-            return retVal;
-        } catch (final Exception e) {
-            currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
+	    if (currentPrincipal != null) {
+		for (int i = 0; i < audits.value().length; i++) {
+		    final AuditActionResolver auditActionResolver = this.auditActionResolvers.get(audits.value()[i].actionResolverName());
+		    final AuditResourceResolver auditResourceResolver = this.auditResourceResolvers.get(audits.value()[i]
+			    .resourceResolverName());
+		    auditableResources[i] = auditResourceResolver.resolveFrom(joinPoint, retVal);
+		    actions[i] = auditActionResolver.resolveFrom(joinPoint, retVal, audits.value()[i]);
+		}
+	    }
+	    return retVal;
+	} catch (final Exception e) {
+	    originalCauses.add(e);
+	    try {
+		currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
 
-            if (currentPrincipal != null) {
-                for (int i = 0; i < audits.value().length; i++) {
-                    auditableResources[i] = this.auditResourceResolvers.get(audits.value()[i].resourceResolverName()).resolveFrom(joinPoint, e);
-                    actions[i] = auditActionResolvers.get(audits.value()[i].actionResolverName()).resolveFrom(joinPoint, e, audits.value()[i]);
-                }
-            }
-            throw e;
-        } finally {
-            for (int i = 0; i < audits.value().length; i++) {
-                executeAuditCode(currentPrincipal, auditableResources[i], joinPoint, retVal, actions[i], audits.value()[i]);
-            }
-        }
+		if (currentPrincipal != null) {
+		    for (int i = 0; i < audits.value().length; i++) {
+			auditableResources[i] = this.auditResourceResolvers.get(audits.value()[i].resourceResolverName()).resolveFrom(
+				joinPoint, e);
+			actions[i] = auditActionResolvers.get(audits.value()[i].actionResolverName()).resolveFrom(joinPoint, e,
+				audits.value()[i]);
+		    }
+		}
+	    } catch (Throwable t2) {
+		if (originalCauses.size() > 0) {
+		    throw new AuditException(t2.getMessage(), t2, originalCauses.toArray(new Throwable[0]));
+		}
+	    }
+
+	    throw e;
+	} finally {
+	    try {
+		for (int i = 0; i < audits.value().length; i++) {
+		    executeAuditCode(currentPrincipal, auditableResources[i], joinPoint, retVal, actions[i], audits.value()[i]);
+		}
+	    } catch (Throwable t) {
+		throw new AuditException(t.getMessage(), t, originalCauses.toArray(new Throwable[0]));
+	    }
+	}
     }
 
     @Around(value = "@annotation(audit)", argNames = "audit")
     public Object handleAuditTrail(final ProceedingJoinPoint joinPoint, final Audit audit) throws Throwable {
-        final AuditActionResolver auditActionResolver = this.auditActionResolvers.get(audit.actionResolverName());
-        final AuditResourceResolver auditResourceResolver = this.auditResourceResolvers.get(audit.resourceResolverName());
+	Throwable originalCause = null;
+	final AuditActionResolver auditActionResolver = this.auditActionResolvers.get(audit.actionResolverName());
+	final AuditResourceResolver auditResourceResolver = this.auditResourceResolvers.get(audit.resourceResolverName());
 
-        String currentPrincipal = null;
-        String[] auditResource = new String[]{null};
-        String action = null;
-        Object retVal = null;
-        try {
-            retVal = joinPoint.proceed();
+	String currentPrincipal = null;
+	String[] auditResource = new String[] { null };
+	String action = null;
+	Object retVal = null;
+	try {
+	    retVal = joinPoint.proceed();
 
-            currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, retVal);
-            auditResource = auditResourceResolver.resolveFrom(joinPoint, retVal);
-            action = auditActionResolver.resolveFrom(joinPoint, retVal, audit);
+	    currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, retVal);
+	    auditResource = auditResourceResolver.resolveFrom(joinPoint, retVal);
+	    action = auditActionResolver.resolveFrom(joinPoint, retVal, audit);
 
-            return retVal;
-        } catch (final Exception e) {
-            currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
-            auditResource = auditResourceResolver.resolveFrom(joinPoint, e);
-            action = auditActionResolver.resolveFrom(joinPoint, e, audit);
-            throw e;
-        } finally {
-            executeAuditCode(currentPrincipal, auditResource, joinPoint, retVal, action, audit);
-        }
+	    return retVal;
+	} catch (final Exception e) {
+	    originalCause = e;
+	    try {
+		currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
+		auditResource = auditResourceResolver.resolveFrom(joinPoint, e);
+		action = auditActionResolver.resolveFrom(joinPoint, e, audit);
+	    } catch (Exception e2) {
+		throw new AuditException(e2.getMessage(), e2, originalCause);
+	    }
+	    throw e;
+	} finally {
+	    try {
+		executeAuditCode(currentPrincipal, auditResource, joinPoint, retVal, action, audit);
+	    } catch (Exception e2) {
+		if (originalCause != null) {
+		    throw new AuditException(e2.getMessage(), e2, originalCause);
+		}
+	    }
+	}
     }
 
-    private void executeAuditCode(final String currentPrincipal, final String[] auditableResources, final ProceedingJoinPoint joinPoint, final Object retVal, final String action, final Audit audit) {
-        final String applicationCode = (audit.applicationCode() != null && audit.applicationCode().length() > 0) ? audit.applicationCode() : this.applicationCode;
-        final ClientInfo clientInfo = this.clientInfoResolver.resolveFrom(joinPoint, retVal);
-        final Date actionDate = new Date();
-        final AuditPointRuntimeInfo runtimeInfo = new AspectJAuditPointRuntimeInfo(joinPoint);
-        for (final String auditableResource : auditableResources) {
-            final AuditActionContext auditContext =
-                    new AuditActionContext(currentPrincipal, auditableResource, action, applicationCode,
-                            actionDate, clientInfo.getClientIpAddress(), clientInfo.getServerIpAddress(), runtimeInfo);
-            // Finally record the audit trail info
-            for (AuditTrailManager manager : auditTrailManagers) {
-                manager.record(auditContext);
-            }
-        }
+    private void executeAuditCode(final String currentPrincipal, final String[] auditableResources, final ProceedingJoinPoint joinPoint,
+	    final Object retVal, final String action, final Audit audit) {
+	final String applicationCode = (audit.applicationCode() != null && audit.applicationCode().length() > 0) ? audit.applicationCode()
+		: this.applicationCode;
+	final ClientInfo clientInfo = this.clientInfoResolver.resolveFrom(joinPoint, retVal);
+	final Date actionDate = new Date();
+	final AuditPointRuntimeInfo runtimeInfo = new AspectJAuditPointRuntimeInfo(joinPoint);
+	for (final String auditableResource : auditableResources) {
+	    final AuditActionContext auditContext = new AuditActionContext(currentPrincipal, auditableResource, action, applicationCode,
+		    actionDate, clientInfo.getClientIpAddress(), clientInfo.getServerIpAddress(), runtimeInfo);
+	    // Finally record the audit trail info
+	    for (AuditTrailManager manager : auditTrailManagers) {
+		manager.record(auditContext);
+	    }
+	}
     }
 
     public void setClientInfoResolver(final ClientInfoResolver factory) {
-        this.clientInfoResolver = factory;
+	this.clientInfoResolver = factory;
     }
 }

--- a/inspektr-common/src/main/java/com/github/inspektr/common/web/ClientInfoThreadLocalFilter.java
+++ b/inspektr-common/src/main/java/com/github/inspektr/common/web/ClientInfoThreadLocalFilter.java
@@ -34,7 +34,7 @@ import javax.servlet.http.HttpServletRequest;
  * <p>
  * If one provides an alternative IP Address Header (i.e. init-param "alternativeIpAddressHeader"), the client
  * IP address will be read from that instead.
- * 
+ *
  * @author Scott Battaglia
  * @version $Revision$ $Date$
  * @since 1.0
@@ -49,12 +49,12 @@ public final class ClientInfoThreadLocalFilter implements Filter {
 	public void destroy() {
 		// nothing to do here
 	}
-	
+
 	public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain filterChain) throws IOException, ServletException {
 		try {
 			final ClientInfo clientInfo;
 
-            if (otherHeader == null || otherHeader.isEmpty()) {
+            if (otherHeader == null || otherHeader.trim().length()==0) {
                 clientInfo = new ClientInfo((HttpServletRequest) request);
             } else {
                 clientInfo = new ClientInfo((HttpServletRequest) request, this.otherHeader);

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
 				<configuration>
-					<source>1.5</source>
+					<source>1.7</source>
 					<target>1.5</target>
 				</configuration>
 			</plugin>
@@ -286,6 +286,8 @@
         <aspectj.version>1.7.4</aspectj.version>
         <javax.servlet.version>2.5</javax.servlet.version>
         <javax.validation.version>1.0.0.GA</javax.validation.version>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.5</maven.compiler.target>
     </properties>
 
 	<modules>


### PR DESCRIPTION
Keep track of the original underlying exception even when auditing fails.
