### PR TITLE
Fix: auditing on Erorr (not only Exception)

### DIFF
--- a/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
+++ b/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
@@ -104,7 +104,7 @@ public class AuditTrailManagementAspect {
                 }
             }
             return retVal;
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
             currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
 
             if (currentPrincipal != null) {


### PR DESCRIPTION
When auditing code was throwing Error auditing information was
not gathered and auditing was not possible and Error causing this
behavior was "swallowed".