### PR TITLE
Fix: auditing on Erorr (not only Exception)

### DIFF
--- a/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
+++ b/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
@@ -138,7 +138,7 @@ public class AuditTrailManagementAspect {
             action = auditActionResolver.resolveFrom(joinPoint, retVal, audit);
 
             return retVal;
-        } catch (final Exception e) {
+        } catch (final Throwable e) {
             currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
             auditResource = auditResourceResolver.resolveFrom(joinPoint, e);
             action = auditActionResolver.resolveFrom(joinPoint, e, audit);


### PR DESCRIPTION
When auditing code was throwing Error auditing information was
not gathered and auditing was not possible. Original error was
hidden by inpektr principal not null assert.