### PR TITLE
Change: allow Java 1.6 usage

### DIFF
--- a/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
+++ b/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
@@ -148,7 +148,7 @@ public class AuditTrailManagementAspect {
         }
     }
 
-    private void executeAuditCode(final String currentPrincipal, final String[] auditableResources, final ProceedingJoinPoint joinPoint, final Object retVal, final String action, final Audit audit) {
+    private void executeAuditCode(final String currentPrincipal, final String[] auditableResources, final ProceedingJoinPoint joinPoint, final Object retVal, final String action, final Audit audit) throws Throwable {
         final String applicationCode = (audit.applicationCode() != null && audit.applicationCode().length() > 0) ? audit.applicationCode() : this.applicationCode;
         final ClientInfo clientInfo = this.clientInfoResolver.resolveFrom(joinPoint, retVal);
         final Date actionDate = new Date();

--- a/pom.xml
+++ b/pom.xml
@@ -272,8 +272,8 @@
         <javax.validation.version>1.0.0.GA</javax.validation.version>
 
         <maven-aspectj-plugin.version>1.7</maven-aspectj-plugin.version>
-        <project.build.sourceVersion>1.7</project.build.sourceVersion>
-        <project.build.targetVersion>1.7</project.build.targetVersion>
+        <project.build.sourceVersion>1.6</project.build.sourceVersion>
+        <project.build.targetVersion>1.6</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Libary works fine with Java 1.6 so we can lower the required Java
version from 1.7 to 1.6 to enable usage on some older Java versions.