### PR TITLE
make sure caught exceptions are audited correctly

### DIFF
--- a/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
+++ b/inspektr-audit/src/main/java/org/apereo/inspektr/audit/AuditTrailManagementAspect.java
@@ -104,16 +104,17 @@ public class AuditTrailManagementAspect {
                 }
             }
             return retVal;
-        } catch (final Throwable e) {
+        } catch (final Throwable t) {
+            final Exception e = wrapIfNecessary(t);
             currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
 
             if (currentPrincipal != null) {
                 for (int i = 0; i < audits.value().length; i++) {
                     auditableResources[i] = this.auditResourceResolvers.get(audits.value()[i].resourceResolverName()).resolveFrom(joinPoint, e);
-                    actions[i] = auditActionResolvers.get(audits.value()[i].actionResolverName()).resolveFrom(joinPoint, (Exception) e, audits.value()[i]);
+                    actions[i] = auditActionResolvers.get(audits.value()[i].actionResolverName()).resolveFrom(joinPoint, e, audits.value()[i]);
                 }
             }
-            throw e;
+            throw t;
         } finally {
             for (int i = 0; i < audits.value().length; i++) {
                 executeAuditCode(currentPrincipal, auditableResources[i], joinPoint, retVal, actions[i], audits.value()[i]);
@@ -138,11 +139,12 @@ public class AuditTrailManagementAspect {
             action = auditActionResolver.resolveFrom(joinPoint, retVal, audit);
 
             return retVal;
-        } catch (final Throwable e) {
+        } catch (final Throwable t) {
+            final Exception e = wrapIfNecessary(t);
             currentPrincipal = this.auditPrincipalResolver.resolveFrom(joinPoint, e);
             auditResource = auditResourceResolver.resolveFrom(joinPoint, e);
-            action = auditActionResolver.resolveFrom(joinPoint, (Exception) e, audit);
-            throw e;
+            action = auditActionResolver.resolveFrom(joinPoint, e, audit);
+            throw t;
         } finally {
             executeAuditCode(currentPrincipal, auditResource, joinPoint, retVal, action, audit);
         }
@@ -198,5 +200,9 @@ public class AuditTrailManagementAspect {
         if (o == null) {
             throw new IllegalArgumentException(message);
         }
+    }
+
+    private Exception wrapIfNecessary(final Throwable t) {
+        return t instanceof Exception ? (Exception) t : new Exception(t);
     }
 }


### PR DESCRIPTION
This safely guarantees that all `Throwables` get passed to the correct `resolveFrom` method.

This fix is appropriate for a minor release, for a major release we should just change the signature of the `resolveFrom` methods.